### PR TITLE
[Fix] Job delay handling, default job checking, and file name collisions.

### DIFF
--- a/central-runner.php
+++ b/central-runner.php
@@ -7,7 +7,7 @@ if (PHP_SAPI !== 'cli') {
 
 const SYS_KEY = '__src_system';
 const SQS_PATH = 'sqs-jobqueue/sqs-worker.php';
-const PER_FILE_THRESHOLD = 5;
+const PER_FILE_THRESHOLD = 13;
 
 $settings = [
     'queuePath' => __DIR__.'/fake-queue',

--- a/code/queuedjobs/SqsScheduleRunnerJob.php
+++ b/code/queuedjobs/SqsScheduleRunnerJob.php
@@ -26,6 +26,7 @@ class SqsScheduleRunnerJob implements SqsIntervalTask {
 
     public function processScheduledJobs() {
         $this->queuedJobService->checkJobHealth();
+        $this->queuedJobService->checkdefaultJobs();
 
         $processedWaiting = false;
         // run waiting jobs that haven't been re-added to the queue

--- a/code/service/FileBasedSqsQueue.php
+++ b/code/service/FileBasedSqsQueue.php
@@ -38,7 +38,7 @@ class FileBasedSqsQueue
 
         $path = $this->getQueuePath();
 
-        $name = md5($data);
+        $name = uniqid(md5($data)."_");
 
         file_put_contents($path.'/'.$name, $data);
     }
@@ -61,7 +61,6 @@ class FileBasedSqsQueue
 
                     //if too young, skip message
                     if($time_alive < $data["DelaySeconds"]) {
-                        echo "[2018-07-18 xx:xx:xx] File too young (".$time_alive."/".$data["DelaySeconds"].")\n";
                         continue;
                     }
                 }


### PR DESCRIPTION
- Default jobs should now be regenerated properly.
- Jobs with a delay should now wait the correct amount of time before being executed.
- Job files that were recreated will no longer override the original file and be immediately deleted.