### PR TITLE
Add job types for checkJobHealth and defaultJobs

### DIFF
--- a/code/queuedjobs/SqsScheduleRunnerJob.php
+++ b/code/queuedjobs/SqsScheduleRunnerJob.php
@@ -25,7 +25,7 @@ class SqsScheduleRunnerJob implements SqsIntervalTask {
 
 
     public function processScheduledJobs() {
-        $queue = array(QueuedJob::QUEUED, SqsQueuedJobExtension::TYPE_SCHEDULED);
+        $queue = array(QueuedJob::QUEUED, QueuedJob::LARGE, SqsQueuedJobExtension::TYPE_SCHEDULED);
 
         $this->queuedJobService->checkJobHealth($queue);
         $this->queuedJobService->checkdefaultJobs($queue);

--- a/code/queuedjobs/SqsScheduleRunnerJob.php
+++ b/code/queuedjobs/SqsScheduleRunnerJob.php
@@ -25,8 +25,10 @@ class SqsScheduleRunnerJob implements SqsIntervalTask {
 
 
     public function processScheduledJobs() {
-        $this->queuedJobService->checkJobHealth();
-        $this->queuedJobService->checkdefaultJobs();
+        $queue = array(QueuedJob::QUEUED, SqsQueuedJobExtension::TYPE_SCHEDULED);
+
+        $this->queuedJobService->checkJobHealth($queue);
+        $this->queuedJobService->checkdefaultJobs($queue);
 
         $processedWaiting = false;
         // run waiting jobs that haven't been re-added to the queue


### PR DESCRIPTION
Add default job types to include QueuedJob::QUEUED, SqsQueuedJobExtension::TYPE_SCHEDULED
This change is for SS3 version (~2.2.0) and NOT to be merged into master which belongs to SS4 version.